### PR TITLE
remove log of the json and allow a json to be passed as an input

### DIFF
--- a/lib/convert.js
+++ b/lib/convert.js
@@ -11,7 +11,6 @@ var priorityMap = [
 var convert = function (output) {
 
   var json = '[' + output.split('\n').filter(x => x && x.includes('"type":"auditAdvisory"')).join(',') + ']';
-  console.log(json);
 
   parsedData = JSON.parse(json);
   report = {};

--- a/parse.js
+++ b/parse.js
@@ -11,11 +11,13 @@ var chunks = [];
 program
   .version(version)
   .option('-o, --out <path>', 'output filename, defaults to gl-dependency-scanning-report.json')
+  .option('-i, --input <path>', 'input filename, defaults to stdin')
   .parse(process.argv);
 
 var filename = program.out || 'gl-dependency-scanning-report.json';
+var input = program.input || '/dev/stdin';
 
-const inputJSON = fs.readFileSync("/dev/stdin", "utf-8");
+const inputJSON = fs.readFileSync(input, "utf-8");
 const outputJSON = convert(inputJSON);
 
 fs.writeFile(filename, outputJSON, function (err) {


### PR DESCRIPTION
I was adding yarn audit to my pipeline as a dependencies scanning step and found your package quite useful. However, I would like to submit the following proposals:

- Delete the console log that outputs the JSON to the console
- Allow passing a file as the input, defaulting to stdin if no input is passed.

The reason for this proposal is due to the following known issue which causes an absurd amount of data to be in the logs of the pipeline and that's not even useful at all since all the important info will be in the final report.
 
https://github.com/yarnpkg/yarn/issues/7404


